### PR TITLE
use MSM in eddsa verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ It allows ZK proofs computed with BLS12-381, a pairing-friendly curve designed f
 ```
 make install
 ```
+As of today, for mac OS, gmpy2 is not supported by brew, so it is required to run a venv to run the library:
+
+```
+python3 -m venv path/to/venv 
+source path/to/venv/bin/activate
+python3 -m venv path/to/venv
+pip3 install --global-option=build_ext --global-option="-I/opt/homebrew/include/" --global-option="-L/opt/homebrew/lib/" gmpy2
+```
 
 ### Generate test vectors (optional, requires `sage`)
 ```

--- a/src/primitives/eddsa.py
+++ b/src/primitives/eddsa.py
@@ -79,6 +79,8 @@ class EdDSA:
             return False
         h = int.from_bytes(hashlib.sha512(
             Rs + self.public_key + str.encode(msg)).digest(), "little") % self.curve.r
-        sB = s*self.curve.generator
-        hA = h * A
-        return sB == R.add(hA)
+        #sB = s*self.curve.generator
+        sBminushA=self.curve.generator.multi_scalar_mul(s,A, self.curve.r-h);#sB-hA
+        #hA = h * A
+        #return sB == R.add(hA)
+        return sBminushA == R #sB-hA == R ?


### PR DESCRIPTION
MSM speed up verification by a factor 40% but is not used prior to the PR.